### PR TITLE
feat: kakao login

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
     <application
         android:label="luckybiky"
         android:name="${applicationName}"

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,10 +13,13 @@ import 'package:kakao_flutter_sdk/kakao_flutter_sdk.dart';
 import 'utils/mapAPI.dart';
 import 'utils/providers/page_provider.dart';
 import 'utils/providers/preference_provider.dart';
+import 'utils/providers/kakao_login_provider.dart';
+
 import 'screens/home.dart';
 import 'screens/searchScreen/search.dart';
 import 'screens/profileScreen/profile.dart';
 import 'utils/login/login.dart';
+import 'utils/login/kakao_login.dart';
 
 
 void main() async {
@@ -37,6 +40,7 @@ void main() async {
       providers: [
         ChangeNotifierProvider(create: (_) => PageProvider()),
         ChangeNotifierProvider(create: (_) => PreferenceProvider()),
+        ChangeNotifierProvider(create: (_) => KakaoLoginProvider()),
       ],
       child: SplashScreen(),
     ),

--- a/lib/screens/profileScreen/preference_survey/kakao_share.dart
+++ b/lib/screens/profileScreen/preference_survey/kakao_share.dart
@@ -1,0 +1,43 @@
+import 'dart:async';
+
+import 'package:kakao_flutter_sdk/kakao_flutter_sdk.dart';
+
+import 'package:url_launcher/url_launcher.dart';
+
+Future<void> kakaoShare() async {
+  // 사용자 정의 템플릿 ID
+  int templateId = 114642; // 실제 템플릿 ID로 교체
+  String url = "https://github.com/jjoing/luckybikey"; // 공유할 웹 페이지 URL
+
+  // 카카오톡 실행 가능 여부 확인
+  bool isKakaoTalkSharingAvailable = await ShareClient.instance.isKakaoTalkSharingAvailable();
+
+  if (isKakaoTalkSharingAvailable) {
+    try {
+      // 카카오톡으로 공유
+      Uri uri = await ShareClient.instance.shareScrap(url: url, templateId: templateId);
+      await ShareClient.instance.launchKakaoTalk(uri);
+      print('카카오톡 공유 완료');
+    } catch (error) {
+      print('카카오톡 공유 실패: $error');
+    }
+  } else {
+    try {
+      // 웹 공유 링크 생성
+      Uri shareUrl = await WebSharerClient.instance.makeScrapUrl(
+        url: url,
+        templateId: templateId,
+        templateArgs: {'key1': 'value1'},
+      );
+      // 브라우저에서 공유 링크 열기
+      if (await canLaunch(shareUrl.toString())) {
+        await launch(shareUrl.toString());
+        print('웹 공유 완료');
+      } else {
+        throw '웹 공유 링크를 열 수 없습니다: ${shareUrl.toString()}';
+      }
+    } catch (error) {
+      print('웹 공유 실패: $error');
+    }
+  }
+}

--- a/lib/screens/profileScreen/preference_survey/survey_result.dart
+++ b/lib/screens/profileScreen/preference_survey/survey_result.dart
@@ -8,6 +8,8 @@ import 'package:provider/provider.dart';
 import 'package:screenshot/screenshot.dart';
 import 'package:image_gallery_saver/image_gallery_saver.dart';
 
+import 'kakao_share.dart';
+
 import '../../../utils/providers/page_provider.dart';
 import '../../../utils/providers/preference_provider.dart';
 
@@ -118,7 +120,7 @@ class SurveyResultPage extends StatelessWidget {
                             ),
                             IconButton(
                               icon: Icon(Icons.share, color: Colors.blue),
-                              onPressed: () => _shareImage(context),
+                              onPressed: () => kakaoShare(),
                               tooltip: '공유',
                             ),
                           ],

--- a/lib/screens/profileScreen/profile.dart
+++ b/lib/screens/profileScreen/profile.dart
@@ -2,11 +2,18 @@ import 'package:flutter/material.dart';
 
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:kakao_flutter_sdk/kakao_flutter_sdk.dart';
 
 import '../../utils/providers/page_provider.dart';
 import '../../utils/providers/preference_provider.dart';
+import '../../utils/providers/kakao_login_provider.dart';
+
 import 'preference_survey/intro.dart';
 import '../../components/bottomNaviBar.dart';
+
+import '../../utils/login/login.dart';
+import '../../utils/login/social_login.dart';
+import '../../utils/login/kakao_login.dart';
 
 
 class Profile extends StatelessWidget {
@@ -14,33 +21,50 @@ class Profile extends StatelessWidget {
   Widget build(BuildContext context) {
     final preferenceProvider = Provider.of<PreferenceProvider>(context);
     final pageProvider = Provider.of<PageProvider>(context, listen: false);
+    final kakaoLoginProvider = Provider.of<KakaoLoginProvider>(context);
+
+    final viewModel = MainViewModel(KakaoLogin());
 
     return Scaffold(
       body: SingleChildScrollView(
         child: Column(
           children: [
             const SizedBox(height: 40),
-            // 프로필 이미지와 닉네임
-            CircleAvatar(
-              radius: 50,
-              backgroundImage: AssetImage('assets/images/profile_image.jpg'),
-            ),
-            const SizedBox(height: 10),
-            Text(
-              'yoonbin',
-              style: TextStyle(
-                fontSize: 24,
-                fontWeight: FontWeight.bold,
-                color: Colors.lightGreen[800],
+            // 프로필 이미지
+            if (kakaoLoginProvider.user?.kakaoAccount?.profile?.profileImageUrl != null)
+              CircleAvatar(
+                radius: 50,
+                backgroundImage: NetworkImage(
+                  kakaoLoginProvider.user?.kakaoAccount?.profile?.profileImageUrl ?? '',
+                ),
+              ),
+            const SizedBox(height: 20),
+            // 닉네임
+            Center(
+              child: Text(
+                kakaoLoginProvider.user?.kakaoAccount?.profile?.nickname ?? '로그인이 필요합니다.',
+                style: TextStyle(
+                  fontSize: 24,
+                  fontWeight: FontWeight.bold,
+                  color: Colors.lightGreen[800],
+                ),
               ),
             ),
+            const SizedBox(height: 20),
+            // 로그인/로그아웃 버튼
             TextButton(
-              onPressed: () {
-                // 로그아웃 로직 추가
+              onPressed: () async {
+                if (kakaoLoginProvider.isLogined) {
+                  // 로그아웃 실행
+                  await kakaoLoginProvider.logout();
+                } else {
+                  // 로그인 실행
+                  await kakaoLoginProvider.login();
+                }
               },
-              child: const Text(
-                '로그아웃',
-                style: TextStyle(color: Colors.redAccent, fontSize: 14),
+              child: Text(
+                kakaoLoginProvider.isLogined ? '로그아웃' : '로그인',
+                style: const TextStyle(color: Colors.redAccent, fontSize: 14),
               ),
             ),
             const SizedBox(height: 20),

--- a/lib/utils/login/kakao_login.dart
+++ b/lib/utils/login/kakao_login.dart
@@ -1,29 +1,46 @@
+import 'package:flutter/material.dart';
+
 import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';
+import 'package:provider/provider.dart';
 
 import 'social_login.dart';
 
-class KakaoLogin implements SocialLogin {
 
+class KakaoLogin implements SocialLogin {
   @override
   Future<bool> login() async {
     try {
-      bool isInstalled = await isKakaoTalkInstalled();
-      if (isInstalled) {
+      if (await isKakaoTalkInstalled()) {
+        // 카카오톡 앱으로 로그인 시도
         try {
           await UserApi.instance.loginWithKakaoTalk();
+          print('카카오톡으로 로그인 성공');
           return true;
         } catch (e) {
-          return false;
+          print('카카오톡 로그인 실패: $e');
+          // 앱 로그인 실패 시 계정으로 로그인 시도
+          try {
+            await UserApi.instance.loginWithKakaoAccount();
+            print('카카오 계정으로 로그인 성공');
+            return true;
+          } catch (e) {
+            print('카카오 계정 로그인 실패: $e');
+            return false;
+          }
         }
       } else {
+        // 카카오톡 미설치: 계정으로 로그인 시도
         try {
           await UserApi.instance.loginWithKakaoAccount();
+          print('카카오 계정으로 로그인 성공');
           return true;
         } catch (e) {
+          print('카카오 계정 로그인 실패: $e');
           return false;
         }
       }
     } catch (e) {
+      print('카카오 로그인 오류: $e');
       return false;
     }
   }
@@ -32,9 +49,21 @@ class KakaoLogin implements SocialLogin {
   Future<bool> logout() async {
     try {
       await UserApi.instance.unlink();
+      print('카카오 로그아웃 성공');
       return true;
-    } catch (error) {
+    } catch (e) {
+      print('카카오 로그아웃 실패: $e');
       return false;
     }
   }
 }
+
+Future<void> getUserInfo() async {
+  try {
+    User user = await UserApi.instance.me();
+    print('사용자 정보: ${user.kakaoAccount?.profile?.nickname}');
+  } catch (e) {
+    print('사용자 정보 가져오기 실패: $e');
+  }
+}
+

--- a/lib/utils/login/login.dart
+++ b/lib/utils/login/login.dart
@@ -1,11 +1,16 @@
 import 'package:flutter/material.dart';
+
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:kakao_flutter_sdk/kakao_flutter_sdk.dart';
+import 'package:provider/provider.dart';
 
 import '../../screens/home.dart';
+
 import 'register.dart';
 import 'kakao_login.dart';
 import 'social_login.dart';
 
+import '../providers/kakao_login_provider.dart';
 
 
 class login extends StatefulWidget {
@@ -25,7 +30,6 @@ class _loginState extends State<login> {
   String userPassword = '';
 
   late ScrollController scrollController;
-
   void _tryValidation() {
     final isValid = _formKey.currentState!.validate();
     if (isValid) {
@@ -41,6 +45,8 @@ class _loginState extends State<login> {
 
   @override
   Widget build(BuildContext context) {
+    final kakaoLoginProvider = Provider.of<KakaoLoginProvider>(context);
+
     return Scaffold(
         resizeToAvoidBottomInset: false,
         body: SafeArea(
@@ -265,16 +271,20 @@ class _loginState extends State<login> {
                         width: MediaQuery.of(context).size.width*0.5,
                         child: IconButton(
                           onPressed: () async {
-                            await viewModel.login();
-                            KakaoLogin();
-                            setState(() {});
-
+                            await kakaoLoginProvider.login();
+                            if (kakaoLoginProvider.isLogined) {
+                              Navigator.push(
+                                context,
+                                MaterialPageRoute(builder: (context) => const Home()),
+                              );
+                            }
                           },
                           icon: Image.asset('assets/images/kakao_login.png',),
                         ),
                       ),
                       TextButton(
                         onPressed: () async{
+                          getUserInfo();
                           print('\n닉네임: ${viewModel.user?.kakaoAccount?.profile?.nickname}');
                         },
                         child: Text('계정 정보 확인'),

--- a/lib/utils/providers/kakao_login_provider.dart
+++ b/lib/utils/providers/kakao_login_provider.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';
+
+class KakaoLoginProvider with ChangeNotifier {
+  bool isLogined = false;
+  User? user;
+
+  Future<void> login() async {
+    try {
+      if (await isKakaoTalkInstalled()) {
+        await UserApi.instance.loginWithKakaoTalk();
+      } else {
+        await UserApi.instance.loginWithKakaoAccount();
+      }
+      isLogined = true;
+      user = await UserApi.instance.me();
+      notifyListeners();
+    } catch (e) {
+      print('카카오 로그인 실패: $e');
+      isLogined = false;
+      user = null;
+      notifyListeners();
+    }
+  }
+
+  Future<void> logout() async {
+    try {
+      await UserApi.instance.logout();
+      isLogined = false;
+      user = null;
+      notifyListeners();
+    } catch (e) {
+      print('카카오 로그아웃 실패: $e');
+    }
+  }
+}

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,10 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
+  url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
 }

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  url_launcher_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -13,6 +13,7 @@ import flutter_tts
 import google_sign_in_ios
 import path_provider_foundation
 import shared_preferences_foundation
+import url_launcher_macos
 import webview_flutter_wkwebview
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
@@ -24,5 +25,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTGoogleSignInPlugin.register(with: registry.registrar(forPlugin: "FLTGoogleSignInPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
+  UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
   FLTWebViewFlutterPlugin.register(with: registry.registrar(forPlugin: "FLTWebViewFlutterPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -781,6 +781,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.2"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: "9d06212b1362abc2f0f0d78e6f09f726608c74e3b9462e8368bb03314aa8d603"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.1"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: "6fc2f56536ee873eeb867ad176ae15f304ccccc357848b351f6f0d8d4a40d193"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.14"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: e43b677296fadce447e987a2f519dcf5f6d1e527dc35d01ffab4fff5b8a7063e
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.1"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: "4e9ba368772369e3e08f231d2301b4ef72b9ff87c31192ef471b380ef29a4935"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "769549c999acdb42b8bcfa7c43d72bf79a382ca7441ab18a808e101149daf672"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: "772638d3b34c779ede05ba3d38af34657a05ac55b06279ea6edd409e323dca8e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.3"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "44cf3aabcedde30f2dba119a9dea3b0f2672fbe6fa96e85536251d678216b3c4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.3"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,6 +53,7 @@ dependencies:
   kakao_flutter_sdk: ^1.9.6
   path_provider: ^2.1.5
   image_gallery_saver: ^2.0.3
+  url_launcher: ^6.3.1
 
 dev_dependencies:
   flutter_test:

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -11,6 +11,7 @@
 #include <firebase_core/firebase_core_plugin_c_api.h>
 #include <flutter_tts/flutter_tts_plugin.h>
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
+#include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   CloudFirestorePluginCApiRegisterWithRegistrar(
@@ -23,4 +24,6 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FlutterTtsPlugin"));
   PermissionHandlerWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
+  UrlLauncherWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -8,6 +8,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   firebase_core
   flutter_tts
   permission_handler_windows
+  url_launcher_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
kakao login provider를 따로 만들어 로그인 이후 user 정보를 다른 위젯에서도 볼 수 있도록 제작,

현재 profile 페이지에서는 kakao login의 경우에만 프로필 이미지와 닉네임 등이 보이는 상태
```
if (kakaoLoginProvider.user?.kakaoAccount?.profile?.profileImageUrl != null)
    CircleAvatar(
      radius: 50,
      backgroundImage: NetworkImage(
        kakaoLoginProvider.user?.kakaoAccount?.profile?.profileImageUrl ?? '',
      ),
    ),
```
와 같은 형태로 kakao login만을 기준으로 하고 있는데 차후 firebase에 kakao를 포함시킨 이후에는 kakao login provider가 아닌 social login 등과 같은 형태로 하나로 통일시킬 필요가 있을 것으로 보임

+) 아직 kakao 관련하여 추가로 해야하는 것 : 
- kakao login 에서 카카오톡이 안 깔려있는 경우에 대한 예외처리 디테일이 부족 (기존에 있었으나 provider를 사용하면서 조금 수정하였기에 기존 커밋 참고하여 복구 예정)
- kakao login을 일반 로그인과 어떻게 합칠 것인지, 혹은 카카오 로그인 만을 허용?
- 타 기기에서 작동하는지 실험 <- 릴리즈 키를 받지 못하였고 디버깅 키만 카카오에 등록하였기에 타 기기에서도 작동이 되는지 확인이 필요
- kakao로 공유하는 기능