### PR TITLE
Yoonbincho

### DIFF
--- a/lib/screens/profileScreen/preference_survey/edit_keyword.dart
+++ b/lib/screens/profileScreen/preference_survey/edit_keyword.dart
@@ -1,0 +1,172 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../../utils/providers/preference_provider.dart';
+
+class EditKeywordsPage extends StatefulWidget {
+  @override
+  _EditKeywordsPageState createState() => _EditKeywordsPageState();
+}
+
+class _EditKeywordsPageState extends State<EditKeywordsPage> {
+  late List<String> likes;
+  late List<String> dislikes;
+  List<String> availableKeywords = [
+    '풍경',
+    '속도',
+    '안전',
+    '신호',
+    '통행량',
+    '오르막',
+  ]; // 수정 가능한 모든 키워드
+
+  @override
+  void initState() {
+    super.initState();
+    final preferenceProvider = Provider.of<PreferenceProvider>(context, listen: false);
+    likes = List<String>.from(preferenceProvider.likes);
+    dislikes = List<String>.from(preferenceProvider.dislikes);
+
+    // 나머지 키워드 리스트에서 이미 선택된 것을 제외
+    availableKeywords.removeWhere((keyword) => likes.contains(keyword) || dislikes.contains(keyword));
+  }
+
+  void _onSave(BuildContext context) {
+    final preferenceProvider = Provider.of<PreferenceProvider>(context, listen: false);
+    preferenceProvider.setLikes(likes);
+    preferenceProvider.setDislikes(dislikes);
+    Navigator.pop(context);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('취향 키워드 수정하기'),
+        backgroundColor: Colors.lightGreen,
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: Column(
+              children: [
+                _buildKeywordSection('좋아요!', Colors.green, likes),
+                _buildKeywordSection('싫어요!', Colors.red, dislikes),
+              ],
+            ),
+          ),
+          Expanded(
+            child: Column(
+              children: [
+                const Text(
+                  '사용 가능한 키워드',
+                  style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                ),
+                Expanded(
+                  child: DragTarget<String>(
+                    onAccept: (data) {
+                      setState(() {
+                        availableKeywords.add(data);
+                        likes.remove(data);
+                        dislikes.remove(data);
+                      });
+                    },
+                    builder: (context, candidateData, rejectedData) {
+                      return Wrap(
+                        spacing: 10,
+                        children: availableKeywords
+                            .map((keyword) => Draggable<String>(
+                          data: keyword,
+                          child: _buildKeywordChip(keyword, Colors.grey),
+                          feedback: _buildKeywordChip(keyword, Colors.grey.withOpacity(0.5)),
+                          childWhenDragging: _buildKeywordChip(keyword, Colors.grey.withOpacity(0.3)),
+                        ))
+                            .toList(),
+                      );
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                backgroundColor: Colors.lightGreen,
+                padding: EdgeInsets.symmetric(vertical: 15, horizontal: 50),
+              ),
+              onPressed: () => _onSave(context),
+              child: const Text(
+                '키워드 저장하기',
+                style: TextStyle(fontSize: 16, color: Colors.white),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildKeywordSection(String title, Color color, List<String> keywords) {
+    return Expanded(
+      child: Column(
+        children: [
+          Text(
+            title,
+            style: TextStyle(
+              fontSize: 18,
+              fontWeight: FontWeight.bold,
+              color: color,
+            ),
+          ),
+          Expanded(
+            child: DragTarget<String>(
+              onAccept: (data) {
+                setState(() {
+                  if (title == '좋아요!') {
+                    likes.add(data);
+                  } else {
+                    dislikes.add(data);
+                  }
+                  availableKeywords.remove(data);
+                });
+              },
+              builder: (context, candidateData, rejectedData) {
+                return Wrap(
+                  spacing: 10,
+                  children: keywords
+                      .map((keyword) => Draggable<String>(
+                    data: keyword,
+                    child: _buildKeywordChip(keyword, color),
+                    feedback: _buildKeywordChip(keyword, color.withOpacity(0.5)),
+                    childWhenDragging: _buildKeywordChip(keyword, color.withOpacity(0.3)),
+                  ))
+                      .toList(),
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildKeywordChip(String keyword, Color color) {
+    return Chip(
+      label: Text(
+        keyword,
+        style: TextStyle(color: Colors.white),
+      ),
+      backgroundColor: color,
+      deleteIcon: Icon(Icons.close, color: Colors.white),
+      onDeleted: () {
+        setState(() {
+          likes.remove(keyword);
+          dislikes.remove(keyword);
+          availableKeywords.remove(keyword);
+        });
+      },
+    );
+  }
+}

--- a/lib/screens/profileScreen/preference_survey/survey_result.dart
+++ b/lib/screens/profileScreen/preference_survey/survey_result.dart
@@ -93,7 +93,7 @@ class SurveyResultPage extends StatelessWidget {
                         ),
                         TextButton(
                           onPressed: () => {
-                            Navigator.pushReplacement(
+                            Navigator.push(
                               context,
                               MaterialPageRoute(
                                 builder: (context) {

--- a/lib/screens/profileScreen/preference_survey/survey_result.dart
+++ b/lib/screens/profileScreen/preference_survey/survey_result.dart
@@ -14,6 +14,8 @@ import '../../../utils/providers/page_provider.dart';
 import '../../../utils/providers/preference_provider.dart';
 import '../../../utils/providers/kakao_login_provider.dart';
 
+import 'edit_keyword.dart';
+
 class SurveyResultPage extends StatelessWidget {
   final ScreenshotController screenshotController = ScreenshotController();
   final String resultType;
@@ -68,17 +70,38 @@ class SurveyResultPage extends StatelessWidget {
                         Wrap(
                           spacing: 10,
                           children: preferenceProvider.likes
-                              .map((like) => Chip(label: Text(like)))
+                              .map((like) => Chip(
+                            label: Text(
+                              like,
+                              style: TextStyle(color: Colors.white),
+                            ),
+                            backgroundColor: Colors.green,
+                          ))
                               .toList(),
                         ),
                         Wrap(
                           spacing: 10,
                           children: preferenceProvider.dislikes
-                              .map((dislike) => Chip(label: Text(dislike)))
+                              .map((dislike) => Chip(
+                            label: Text(
+                              dislike,
+                              style: TextStyle(color: Colors.white),
+                            ),
+                            backgroundColor: Colors.red,
+                          ))
                               .toList(),
                         ),
                         TextButton(
-                          onPressed: () async {},
+                          onPressed: () => {
+                            Navigator.pushReplacement(
+                              context,
+                              MaterialPageRoute(
+                                builder: (context) {
+                                  return EditKeywordsPage();
+                                },
+                              ),
+                            )
+                          },
                           child: Text(
                             '취향 키워드 수정하기',
                             style: const TextStyle(

--- a/lib/utils/providers/preference_provider.dart
+++ b/lib/utils/providers/preference_provider.dart
@@ -1,58 +1,49 @@
 import 'package:flutter/material.dart';
 
 class PreferenceProvider with ChangeNotifier {
-  List<String> likes = [];
-  List<String> dislikes = [];
+  List<String> _likes = [];
+  List<String> _dislikes = [];
 
-  void addLike(String item) {
-    if (!likes.contains(item)) {
-      likes.add(item);
+  List<String> get likes => _likes;
+  List<String> get dislikes => _dislikes;
+
+  // Method to set likes
+  void setLikes(List<String> likes) {
+    _likes = likes;
+    notifyListeners();
+  }
+
+  // Method to set dislikes
+  void setDislikes(List<String> dislikes) {
+    _dislikes = dislikes;
+    notifyListeners();
+  }
+
+  // Method to add a single like
+  void addLike(String like) {
+    if (!_likes.contains(like)) {
+      _likes.add(like);
       notifyListeners();
     }
   }
 
-  void addDislike(String item) {
-    if (!dislikes.contains(item)) {
-      dislikes.add(item);
+  // Method to remove a single like
+  void removeLike(String like) {
+    _likes.remove(like);
+    notifyListeners();
+  }
+
+  // Method to add a single dislike
+  void addDislike(String dislike) {
+    if (!_dislikes.contains(dislike)) {
+      _dislikes.add(dislike);
       notifyListeners();
     }
   }
 
-  void removeLike(String item) {
-    if (likes.contains(item)) {
-      likes.remove(item);
-      notifyListeners();
-    }
-  }
-
-  void removeDislike(String item) {
-    if (dislikes.contains(item)) {
-      dislikes.remove(item);
-      notifyListeners();
-    }
-  }
-
-  void toggleLike(String item) {
-    if (likes.contains(item)) {
-      removeLike(item);
-    } else {
-      addLike(item);
-    }
-  }
-
-  void toggleDislike(String item) {
-    if (dislikes.contains(item)) {
-      removeDislike(item);
-    } else {
-      addDislike(item);
-    }
-  }
-
-  bool isLiked(String item) {
-    return likes.contains(item);
-  }
-
-  bool isDisliked(String item) {
-    return dislikes.contains(item);
+  // Method to remove a single dislike
+  void removeDislike(String dislike) {
+    _dislikes.remove(dislike);
+    notifyListeners();
   }
 }

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -10,6 +10,7 @@ import cloud_functions
 import firebase_auth
 import firebase_core
 import flutter_tts
+import geolocator_apple
 import google_sign_in_ios
 import path_provider_foundation
 import shared_preferences_foundation
@@ -22,6 +23,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseAuthPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAuthPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
   FlutterTtsPlugin.register(with: registry.registrar(forPlugin: "FlutterTtsPlugin"))
+  GeolocatorPlugin.register(with: registry.registrar(forPlugin: "GeolocatorPlugin"))
   FLTGoogleSignInPlugin.register(with: registry.registrar(forPlugin: "FLTGoogleSignInPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -87,7 +87,6 @@ flutter:
     - assets/images/survey_result/health.webp
     - assets/images/survey_result/safety.webp
     - assets/images/survey_result/scenery.webp
-    - assets/images/nav_icon.png
 
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/assets-and-images/#resolution-aware

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -10,6 +10,7 @@
 #include <firebase_auth/firebase_auth_plugin_c_api.h>
 #include <firebase_core/firebase_core_plugin_c_api.h>
 #include <flutter_tts/flutter_tts_plugin.h>
+#include <geolocator_windows/geolocator_windows.h>
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
@@ -22,6 +23,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FirebaseCorePluginCApi"));
   FlutterTtsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterTtsPlugin"));
+  GeolocatorWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("GeolocatorWindows"));
   PermissionHandlerWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
   UrlLauncherWindowsRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -7,6 +7,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   firebase_auth
   firebase_core
   flutter_tts
+  geolocator_windows
   permission_handler_windows
   url_launcher_windows
 )


### PR DESCRIPTION
preference survey 파트를 거의 완료했습니다.

profile -> intro -> survey -> survey_result 페이지의 흐름으로 넘어가게 되고 이는 전부 preference survey 폴더 안에 별도의 파일로 정리해서 코드를 작성하였습니다.

intro에서 설명을 보고 survey 페이지로 넘어가면 질문 문항별로 2지선다의 심리테스트를 진행합니다.
해당 테스트에서 뽑아낸 키워드를 바탕으로 survey_result 페이지에서 대표 4가지 유형으로 나누어 결과를 보여줍니다. 

이때 저희의 키워드는 like 속성과 dislike 속성으로 분류하여 키워드를 가지고 있고, like는 초록색, dislike는 빨간색 키워드 박스를 보이게 작성하였습니다.

+) 이번 수정안은 survey result 페이지에서 취향 키워드 수정하기 버튼을 누르면 키워드 드래그로 선호 취향 키워드를 수정할 수 있도록 하였습니다. 해당 내용은 provider로 관리중이기에 수정 후 자동으로 전체 페이지에 반영이 됩니다..!! ㅎㅎ

survey result 페이지에서 다운로드 버튼을 누르면 해당 위젯을 캡쳐하여 핸드폰에 저장하고, 공유 버튼을 누르면 카카오톡으로 저희 앱을 공유할 수 있습니다. 현재는 github 링크로 연결되도록 해두었습니다. 
-> screenshot이 함께 반영되도록 수정해보고 싶으나 중요한 부분이 아니기에 다른 중요한 부분을 건드린 후 시도해보겠습니다.

이제 이 survey 키워드를 서버에서 유저 정보로 함께 저장하고, 그를 선호 반영하여 길찾기를 하면 저희 앱의 가장 중요한 핵심 파트가 완성되는 것입니다..!! 짱짱~
