### PR TITLE
feat: feedback with double tap

### DIFF
--- a/lib/screens/searchScreen/feedback/feedback_function.dart
+++ b/lib/screens/searchScreen/feedback/feedback_function.dart
@@ -1,0 +1,6 @@
+import 'package:flutter/material.dart';
+
+Future feedback() {
+  print('feedback is working!');
+  return feedback();
+}

--- a/lib/screens/searchScreen/feedback/tap_widget.dart
+++ b/lib/screens/searchScreen/feedback/tap_widget.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'feedback_function.dart';
+
+class tapWidget extends StatefulWidget {
+  const tapWidget({super.key});
+
+  @override
+  State<tapWidget> createState() => _tapWidgetState();
+}
+
+class _tapWidgetState extends State<tapWidget> {
+
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+
+      // 피드백으로 더블탭 감지 시 feedback 함수 실행
+      onDoubleTap: feedback,
+
+      // 피드백을 감지하기 위한 double tap 영역
+      child: Container(
+        width: MediaQuery.of(context).size.width*0.9,
+        height: MediaQuery.of(context).size.height*0.4,
+        decoration: BoxDecoration(
+          color: Colors.lightGreen.withOpacity(0.3),
+          borderRadius: BorderRadius.circular(20),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.grey.withOpacity(0.3),
+              spreadRadius: 3,
+              blurRadius: 5,
+              offset: Offset(0, 3),
+            ),
+          ],
+        ),
+        child: Center(
+          child: Text(
+            'Double Tap Here if you are satisfied with your road!!',
+            style: TextStyle(
+              color: Colors.white,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ),
+      )
+    );
+  }
+}


### PR DESCRIPTION
더블 탭 모션을 통해 노드에 대한 유저의 피드백을 받을 수 있는 기능을 추가하는 단계입니다.

search screen > feedback 폴더에서 tap_widget.dart에 있는 tapWidget이 더블탭을 인식하여 피드백 함수를 실행하는 파트입니다.

피드백 함수의 경우 feedback 폴더의 feedback_function.dart 파일의 feedback() 함수 내에 작성을 하면 반영이 될 예정입니다.

추가로 해야하는 것은 feedback을 받을 위젯을 실행시키기 위해 속도가 0이 되었을 때... 등의 상황을 감지해서 실행시키는 코드가 필요합니다. 화이팅...